### PR TITLE
Test

### DIFF
--- a/frontend/src/components/gameCenter/battle/ChatPanelComponent.vue
+++ b/frontend/src/components/gameCenter/battle/ChatPanelComponent.vue
@@ -29,20 +29,82 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, PropType, watch, nextTick } from 'vue'
+import { defineComponent, PropType, watch, nextTick, ref } from 'vue'
+import { useGameStore } from '../../../stores/gameStore'
+import { battleMessages } from '../../../config/messages'
 
 export default defineComponent({
   name: 'ChatPanelComponent',
   props: {
-    chatMessages: {
+    team1: {
       type: Array as PropType<any[]>,
       required: true,
     },
+    team2: {
+      type: Array as PropType<any[]>,
+      required: true,
+    },
+    battleId: {
+      type: [String, Number],
+      default: 0,
+    },
   },
   setup(props) {
+    const gameStore = useGameStore()
+    const gameTime = ref(120) // 120 s -> 02:00 min
+    const chatMessages = ref<any[]>([])
+
+    function showRandomChatMessagesSequentially() {
+      chatMessages.value = []
+
+      if (!props.team1.length || !props.team2.length) {
+        setTimeout(() => showRandomChatMessagesSequentially(), 100)
+        return
+      }
+      const messages = [...battleMessages]
+
+      function showNext() {
+        if (messages.length === 0) return
+        const idx = Math.floor(Math.random() * messages.length)
+        const msg = messages[idx]
+        let chatMsg
+        if (typeof msg === 'string') {
+          const allChampions = [
+            ...props.team1.map((champ) => ({ name: champ.name, team: 1 })),
+            ...props.team2.map((champ) => ({ name: champ.name, team: 2 })),
+          ]
+
+          const randomChampion = allChampions[Math.floor(Math.random() * allChampions.length)]
+
+          chatMsg = {
+            user: randomChampion.name,
+            text: msg,
+            time: formatTime(gameTime.value),
+            team: randomChampion.team,
+          }
+        }
+        chatMessages.value.push(chatMsg)
+        messages.splice(idx, 1)
+        gameTime.value += getRandomTimeIncrement()
+        if (messages.length > 0) {
+          setTimeout(showNext, gameStore.gameSpeed)
+        }
+      }
+      showNext()
+    }
+
+    function formatTime(seconds: number) {
+      const min = Math.floor(seconds / 60)
+      const sec = seconds % 60
+      return `${min.toString().padStart(2, '0')}:${sec.toString().padStart(2, '0')}`
+    }
+    function getRandomTimeIncrement() {
+      return Math.floor(Math.random() * 471) + 30
+    }
+
     // Automatisches Scrollen zum neuesten Chat-Eintrag
     watch(
-      () => props.chatMessages.length,
+      () => chatMessages.value.length,
       async () => {
         await nextTick()
         const chatBox = document.getElementById('battle-chat-box')
@@ -51,7 +113,22 @@ export default defineComponent({
         }
       },
     )
-    return {}
+
+    // Watcher für battleId - lädt Chats neu bei jedem neuen Battle
+    // Der immediate: true sorgt dafür, dass beim ersten Laden die Chats geladen werden
+    watch(
+      () => props.battleId,
+      () => {
+        gameTime.value = 120 // Reset game time
+        showRandomChatMessagesSequentially()
+      },
+      { immediate: true }
+    )
+
+    return {
+      chatMessages,
+      showRandomChatMessagesSequentially,
+    }
   },
 })
 </script>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor chat panel to correctly reload messages on new battles and prevent duplicate initial messages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, `onMounted` and a `watch` with `immediate: true` both triggered the chat loading function on the first battle, leading to duplicate messages. This change removes the redundant `onMounted` call, ensuring chats are loaded only once initially and then correctly reloaded for each subsequent battle.

---

[Open in Web](https://cursor.com/agents?id=bc-e869beae-939f-4151-906f-a4349d21e3b7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e869beae-939f-4151-906f-a4349d21e3b7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)